### PR TITLE
Fix choose event when randomat_choose_vote is 0

### DIFF
--- a/lua/randomat2/cl_events/cl_choose.lua
+++ b/lua/randomat2/cl_events/cl_choose.lua
@@ -104,8 +104,8 @@ net.Receive("ChooseVoteTrigger", function()
             end
         end
     end)
+end)
 
-    net.Receive("ChooseVoteEnd", function()
-        closeAllChooseFrames()
-    end)
+net.Receive("ChooseVoteEnd", function()
+    closeAllChooseFrames()
 end)

--- a/lua/randomat2/events/choose.lua
+++ b/lua/randomat2/events/choose.lua
@@ -59,31 +59,32 @@ function EVENT:Begin()
         net.WriteTable(EventChoices)
         net.Broadcast()
 
-        timer.Create("RdmtChooseVoteTimer",GetConVar("randomat_choose_votetimer"):GetInt(), 1, function()
-            local vts = -1
-            local evnt = ""
-            for k, v in RandomPairs(EventVotes) do
-                if vts < v then
-                    vts = v
-                    evnt = k
-                end
-            end
-            for _, v in pairs(Randomat.Events) do
-                local title = Randomat:GetEventTitle(v)
-                if title == evnt then
-                    Randomat:TriggerEvent(v.id, owner)
-                end
-            end
-            net.Start("ChooseVoteEnd")
-            net.Broadcast()
-            EventVotes = {}
-        end)
     else
         net.Start("ChooseEventTrigger")
         net.WriteInt(GetConVarNumber("randomat_choose_choices"), 32)
         net.WriteTable(EventChoices)
         net.Send(owner)
     end
+
+    timer.Create("RdmtChooseVoteTimer",GetConVar("randomat_choose_votetimer"):GetInt(), 1, function()
+        local vts = -1
+        local evnt = ""
+        for k, v in RandomPairs(EventVotes) do
+            if vts < v then
+                vts = v
+                evnt = k
+            end
+        end
+        for _, v in pairs(Randomat.Events) do
+            local title = Randomat:GetEventTitle(v)
+            if title == evnt then
+                Randomat:TriggerEvent(v.id, owner)
+            end
+        end
+        net.Start("ChooseVoteEnd")
+        net.Broadcast()
+        EventVotes = {}
+    end)
 end
 
 function EVENT:End()


### PR DESCRIPTION
Choose event window would be left open if no event chosen.
The player would then be able to continually click on all the events presented, repeatedly triggering them.