### PR TITLE
Vertical formatting support

### DIFF
--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -72,76 +72,43 @@ local function ProcessFormattedSegments(messageSegments, big)
         local shadow = seg.shadow or false
         local outline = seg.outline or false
         local newline = seg.newline or false
-        local descend = seg.descend or false
-        local ascend = seg.ascend or false
-        local vertical = (not seg.descend) and seg.vertical or false
+
+        local layoutShape = nil
+        if seg.descend then
+            layoutShape = "descend"
+        elseif seg.ascend then
+            layoutShape = "ascend"
+        elseif seg.vertical then
+            layoutShape = "vertical"
+        end
 
         local fontName = BuildFormattedFont(bold, italic, underline, strikethrough, shadow, outline, big)
         SurfaceSetFont(fontName)
 
         local exploded = {}
 
-        if descend then
-            exploded = StringSplit(seg.text, "")
+        if layoutShape then
+            local exploded = StringSplit(seg.text, "")
 
             for i, splitString in ipairs(exploded) do
                 local segW, segH = SurfaceGetTextSize(splitString)
 
-                local descend = i ~= 1
+                local hasShape = (i ~= 1)
 
-                TableInsert(segments, {
-                    text = splitString,
-                    font = fontName,
-                    width = segW,
-                    height = segH,
-                    underline = underline,
+                local newSeg = {
+                    text          = splitString,
+                    font          = fontName,
+                    width         = segW,
+                    height        = segH,
+                    underline     = underline,
                     strikethrough = strikethrough,
-                    outline = outline,
-                    newline = newline,
-                    descend = descend,
-                })
-            end
-        elseif ascend then
+                    outline       = outline,
+                    newline       = newline,
+                }
 
-            print("Exploding ascend")
-            exploded = StringSplit(seg.text, "")
+                newSeg[layoutShape] = hasShape
 
-            for i, splitString in ipairs(exploded) do
-                local segW, segH = SurfaceGetTextSize(splitString)
-
-                local ascend = i ~= 1
-
-                TableInsert(segments, {
-                    text = splitString,
-                    font = fontName,
-                    width = segW,
-                    height = segH,
-                    underline = underline,
-                    strikethrough = strikethrough,
-                    outline = outline,
-                    newline = newline,
-                    ascend = ascend,
-                })
-            end
-        elseif vertical then
-            exploded = StringSplit(seg.text, "")
-
-            for i, splitString in ipairs(exploded) do
-                local segW, segH = SurfaceGetTextSize(splitString)
-
-                local vertical = i ~= 1
-
-                TableInsert(segments, {
-                    text = splitString,
-                    font = fontName,
-                    width = segW,
-                    height = segH,
-                    underline = underline,
-                    strikethrough = strikethrough,
-                    outline = outline,
-                    newline = newline,
-                    vertical = vertical,
-                })
+                TableInsert(segments, newSeg)
             end
         else
             local segW, segH = SurfaceGetTextSize(seg.text)

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -68,19 +68,45 @@ local function ProcessFormattedSegments(messageSegments, big)
         local outline = seg.outline or false
 
         local fontName = BuildFormattedFont(bold, italic, underline, strikethrough, shadow, outline, big)
-
         SurfaceSetFont(fontName)
-        local segW, segH = SurfaceGetTextSize(seg.text)
 
-        TableInsert(segments, {
-            text = seg.text,
-            font = fontName,
-            width = segW,
-            height = segH,
-            underline = underline,
-            strikethrough = strikethrough,
-            outline = outline,
-        })
+        local newLines = string.find(seg.text, "\n", 1)
+        local exploded = {}
+
+        if newLines then
+            local startDrop = StartsWith(seg.text, "\n")
+            exploded = string.Split(seg.text, "\n")
+
+            for i, splitString in ipairs(exploded) do
+                local segW, segH = SurfaceGetTextSize(splitString)
+
+                local drop = Either(i == 1, startDrop, true)
+
+                TableInsert(segments, {
+                    text = splitString,
+                    font = fontName,
+                    width = segW,
+                    height = segH,
+                    underline = underline,
+                    strikethrough = strikethrough,
+                    outline = outline,
+                    drop = drop
+                })
+            end
+
+        else
+            local segW, segH = SurfaceGetTextSize(seg.text)
+
+            TableInsert(segments, {
+                text = seg.text,
+                font = fontName,
+                width = segW,
+                height = segH,
+                underline = underline,
+                strikethrough = strikethrough,
+                outline = outline,
+            })
+        end
     end
 
     return segments
@@ -89,14 +115,19 @@ end
 -- Calculate how big the message is
 local function MeasureSegments(segments)
     local totalW = 0
-    local maxH = 0
+    -- no need to measure maxH for segments as it's always the same
+    local totalH = 0
+    local baseH = 0
 
     for _, seg in ipairs(segments) do
         totalW = totalW + seg.width
-        if seg.height > maxH then maxH = seg.height end
+        if baseH == 0 then baseH = seg.height end
+        if seg.drop then totalH = totalH + seg.height end
     end
 
-    return totalW, maxH
+    totalH = totalH + baseH
+
+    return totalW, totalH
 end
 
 local COLOR_DEFAULT = Color(255, 200, 0)
@@ -272,11 +303,16 @@ local function ShowMessage()
 
         function content:Paint(w, h)
             local segX = 0 + (padding / 2)
+            local segY = 0
 
             for _, seg in ipairs(paintSegments) do
+                if seg.drop then
+                    segY = segY + seg.height
+                end
+
                 SurfaceSetFont(seg.font)
                 SurfaceSetTextColor(font_color)
-                SurfaceSetTextPos(segX, 0)
+                SurfaceSetTextPos(segX, segY)
                 SurfaceDrawText(seg.text)
 
                 -- Strike-through line

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -66,6 +66,7 @@ local function ProcessFormattedSegments(messageSegments, big)
         local strikethrough = seg.strikethrough or false
         local shadow = seg.shadow or false
         local outline = seg.outline or false
+        local linebreak = seg.linebreak or false
 
         local fontName = BuildFormattedFont(bold, italic, underline, strikethrough, shadow, outline, big)
         SurfaceSetFont(fontName)
@@ -90,7 +91,8 @@ local function ProcessFormattedSegments(messageSegments, big)
                     underline = underline,
                     strikethrough = strikethrough,
                     outline = outline,
-                    drop = drop
+                    linebreak = linebreak,
+                    drop = drop,
                 })
             end
 
@@ -105,6 +107,7 @@ local function ProcessFormattedSegments(messageSegments, big)
                 underline = underline,
                 strikethrough = strikethrough,
                 outline = outline,
+                linebreak = linebreak,
             })
         end
     end
@@ -114,17 +117,20 @@ end
 
 -- Calculate how big the message is
 local function MeasureSegments(segments)
+    local baseW = 0
     local totalW = 0
     -- no need to measure maxH for segments as it's always the same
     local totalH = 0
     local baseH = 0
 
     for _, seg in ipairs(segments) do
-        totalW = totalW + seg.width
+        if seg.width > baseW then baseW = seg.width end
+        if not seg.linebreak then totalW = totalW + seg.width end
         if baseH == 0 then baseH = seg.height end
-        if seg.drop then totalH = totalH + seg.height end
+        if seg.drop or seg.linebreak then totalH = totalH + seg.height end
     end
 
+    totalW = math.max(totalW, baseW)
     totalH = totalH + baseH
 
     return totalW, totalH
@@ -306,9 +312,11 @@ local function ShowMessage()
             local segY = 0
 
             for _, seg in ipairs(paintSegments) do
-                if seg.drop then
+                if seg.drop or seg.linebreak then
                     segY = segY + seg.height
                 end
+
+                if seg.linebreak then segX = 0 + (padding / 2) end
 
                 SurfaceSetFont(seg.font)
                 SurfaceSetTextColor(font_color)

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -7,6 +7,8 @@ local vgui = vgui
 
 local MathMax = math.max
 local StringSub = string.sub
+local StartsWith = string.StartsWith
+local EndsWith = string.EndsWith
 local SurfaceCreateFont = surface.CreateFont
 local SurfaceDrawText = surface.DrawText
 local SurfaceDrawRect = surface.DrawRect
@@ -170,8 +172,8 @@ local function DrawFormattingLine(seg, segX, font_color, offset)
     local blankLength = 0
     local spaceW = SurfaceGetTextSize(" ")
 
-    local hasLeadSpace = StringSub(seg.text, 1, 1) == " "
-    local hasTrailSpace = StringSub(seg.text, -1) == " "
+    local hasLeadSpace = StartsWith(seg.text, " ")
+    local hasTrailSpace = EndsWith(seg.text, " ")
 
     if hasLeadSpace then
         startOffset = spaceW

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -162,24 +162,42 @@ end
 -- Calculate how big the message is
 local function MeasureSegments(segments)
     local baseW = 0
-    local totalW = 0
+    local msgW = 0
     -- no need to measure maxH for segments as it's always the same
-    local totalDown = 0
-    local totalUp = 0
+    local currentY = 0
+    local maxY = 0
+    local minY = 0
     local baseH = 0
 
     for _, seg in ipairs(segments) do
-        if seg.width > baseW then baseW = seg.width end
-        if not seg.newline then totalW = totalW + seg.width end
-        if baseH == 0 then baseH = seg.height end
-        if seg.descend or seg.newline or seg.vertical then totalDown = totalDown + seg.height end
-        if seg.ascend then totalUp = totalUp + seg.height end
+        if seg.width > baseW then
+            baseW = seg.width
+        end
+
+        if not (seg.newline or seg.vertical) then
+            msgW = msgW + seg.width
+        end
+
+        if baseH == 0 then
+            baseH = seg.height
+        end
+
+        if seg.descend or seg.newline or seg.vertical then
+            currentY = currentY + seg.height
+            if currentY > maxY then maxY = currentY end
+        end
+
+        if seg.ascend then
+            currentY = currentY - seg.height
+            if currentY < minY then minY = currentY end
+        end
     end
 
-    totalW = math.max(totalW, baseW)
-    local totalH = math.max(totalDown, totalUp) + baseH
+    msgW = math.max(msgW, baseW)
+    local msgH = maxY - minY + baseH
+    local yOffset = math.abs(minY)
 
-    return totalW, totalDown, totalUp, baseH
+    return msgW, msgH, yOffset
 end
 
 local COLOR_DEFAULT = Color(255, 200, 0)
@@ -310,9 +328,9 @@ local function ShowMessage()
         
         createdFonts = {}
         segments = ProcessFormattedSegments(msg, big)
-        msgW, totalDown, totalUp, baseH = MeasureSegments(segments)
-        msgH = math.max(totalDown, totalUp) + baseH
-        yOffset = (totalUp - totalDown) > 0 and (totalUp - totalDown) or 0
+        msgW, msgH, yOffset = MeasureSegments(segments)
+        -- msgH = totalDown - totalUp + baseH -- math.max(totalDown, totalUp) + baseH
+        -- yOffset = (totalUp - totalDown) > 0 and (totalUp - totalDown) or 0
     else
         SurfaceSetFont(big and "RandomatHeader" or "RandomatSmallMsg")
         msgW, msgH = SurfaceGetTextSize(msg)

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -21,6 +21,9 @@ local SurfaceSetTextPos = surface.SetTextPos
 local TableInsert = table.insert
 local TableRemove = table.remove
 local VguiCreate = vgui.Create
+local StringReplace = string.Replace
+local StringSplit = string.Split
+local MathAbs = math.abs
 
 SurfaceCreateFont("RandomatHeader", {
     font = "Roboto",
@@ -59,7 +62,7 @@ local function ProcessFormattedSegments(messageSegments, big)
 
     for _, seg in ipairs(messageSegments) do
         if not seg.text then continue end
-        seg.text = string.Replace(seg.text, "\n", "")
+        seg.text = StringReplace(seg.text, "\n", "")
         if seg.text == "" then continue end
 
         local bold = seg.bold or false
@@ -79,7 +82,7 @@ local function ProcessFormattedSegments(messageSegments, big)
         local exploded = {}
 
         if descend then
-            exploded = string.Split(seg.text, "")
+            exploded = StringSplit(seg.text, "")
 
             for i, splitString in ipairs(exploded) do
                 local segW, segH = SurfaceGetTextSize(splitString)
@@ -101,7 +104,7 @@ local function ProcessFormattedSegments(messageSegments, big)
         elseif ascend then
 
             print("Exploding ascend")
-            exploded = string.Split(seg.text, "")
+            exploded = StringSplit(seg.text, "")
 
             for i, splitString in ipairs(exploded) do
                 local segW, segH = SurfaceGetTextSize(splitString)
@@ -121,7 +124,7 @@ local function ProcessFormattedSegments(messageSegments, big)
                 })
             end
         elseif vertical then
-            exploded = string.Split(seg.text, "")
+            exploded = StringSplit(seg.text, "")
 
             for i, splitString in ipairs(exploded) do
                 local segW, segH = SurfaceGetTextSize(splitString)
@@ -193,9 +196,9 @@ local function MeasureSegments(segments)
         end
     end
 
-    msgW = math.max(msgW, baseW)
+    msgW = MathMax(msgW, baseW)
     local msgH = maxY - minY + baseH
-    local yOffset = math.abs(minY)
+    local yOffset = MathAbs(minY)
 
     return msgW, msgH, yOffset
 end
@@ -329,8 +332,6 @@ local function ShowMessage()
         createdFonts = {}
         segments = ProcessFormattedSegments(msg, big)
         msgW, msgH, yOffset = MeasureSegments(segments)
-        -- msgH = totalDown - totalUp + baseH -- math.max(totalDown, totalUp) + baseH
-        -- yOffset = (totalUp - totalDown) > 0 and (totalUp - totalDown) or 0
     else
         SurfaceSetFont(big and "RandomatHeader" or "RandomatSmallMsg")
         msgW, msgH = SurfaceGetTextSize(msg)
@@ -387,7 +388,7 @@ local function ShowMessage()
             for _, seg in ipairs(paintSegments) do
                 SurfaceSetFont(seg.font)
 
-                preceedingCharacterW, _ = surface.GetTextSize(lastChar)
+                preceedingCharacterW, _ = SurfaceGetTextSize(lastChar)
 
                 if seg.descend or seg.newline then
                     segY = segY + seg.height
@@ -410,13 +411,11 @@ local function ShowMessage()
 
                 -- Strike-through line
                 if seg.strikethrough then
-                    -- seg.width, _ = surface.GetTextSize(seg.text)
                     DrawFormattingLine(seg, segX, segY, font_color, 0.55)
                 end
 
                 -- Underline
                 if seg.underline then
-                    -- seg.width, _ = surface.GetTextSize(seg.text)
                     DrawFormattingLine(seg, segX, segY, font_color, 0.87)
                 end
 

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -68,22 +68,22 @@ local function ProcessFormattedSegments(messageSegments, big)
         local strikethrough = seg.strikethrough or false
         local shadow = seg.shadow or false
         local outline = seg.outline or false
-        local newline = seg.newline or nil
-        local cascade = seg.cascade or nil
-        local vertical = (not cascade) and seg.vertical or nil
+        local newline = seg.newline or false
+        local descend = seg.descend or false
+        local vertical = (not seg.descend) and seg.vertical or false
 
         local fontName = BuildFormattedFont(bold, italic, underline, strikethrough, shadow, outline, big)
         SurfaceSetFont(fontName)
 
         local exploded = {}
 
-        if cascade then
+        if descend then
             exploded = string.Split(seg.text, "")
 
             for i, splitString in ipairs(exploded) do
                 local segW, segH = SurfaceGetTextSize(splitString)
 
-                local drop = i ~= 1
+                local descend = i ~= 1
 
                 TableInsert(segments, {
                     text = splitString,
@@ -94,10 +94,29 @@ local function ProcessFormattedSegments(messageSegments, big)
                     strikethrough = strikethrough,
                     outline = outline,
                     newline = newline,
-                    drop = drop,
+                    descend = descend,
                 })
             end
+        elseif vertical then
+            exploded = string.Split(seg.text, "")
 
+            for i, splitString in ipairs(exploded) do
+                local segW, segH = SurfaceGetTextSize(splitString)
+
+                local vertical = i ~= 1
+
+                TableInsert(segments, {
+                    text = splitString,
+                    font = fontName,
+                    width = segW,
+                    height = segH,
+                    underline = underline,
+                    strikethrough = strikethrough,
+                    outline = outline,
+                    newline = newline,
+                    vertical = vertical,
+                })
+            end
         else
             local segW, segH = SurfaceGetTextSize(seg.text)
 
@@ -129,7 +148,7 @@ local function MeasureSegments(segments)
         if seg.width > baseW then baseW = seg.width end
         if not seg.newline then totalW = totalW + seg.width end
         if baseH == 0 then baseH = seg.height end
-        if seg.drop or seg.newline then totalH = totalH + seg.height end
+        if seg.descend or seg.newline or seg.vertical then totalH = totalH + seg.height end
     end
 
     totalW = math.max(totalW, baseW)
@@ -206,7 +225,7 @@ local function RepositionStack()
     end
 end
 
-local function DrawFormattingLine(seg, segX, font_color, offset)
+local function DrawFormattingLine(seg, segX, segY, font_color, offset)
     local startOffset = 0
     local blankLength = 0
     local spaceW = SurfaceGetTextSize(" ")
@@ -222,7 +241,7 @@ local function DrawFormattingLine(seg, segX, font_color, offset)
         blankLength = blankLength + spaceW
     end
 
-    local lineY = offset * seg.height
+    local lineY = segY + offset * seg.height
     local lineWidth = seg.width - blankLength
 
     if seg.outline then
@@ -312,30 +331,44 @@ local function ShowMessage()
         function content:Paint(w, h)
             local segX = 0 + (padding / 2)
             local segY = 0
+            local preceedingCharacterW = 0
+            local lastChar = ""
 
             for _, seg in ipairs(paintSegments) do
-                if seg.drop or seg.newline then
+                SurfaceSetFont(seg.font)
+
+                preceedingCharacterW, _ = surface.GetTextSize(lastChar)
+
+                if seg.descend or seg.newline then
                     segY = segY + seg.height
+                end
+
+                if seg.vertical then
+                    segY = segY + seg.height
+                    segX = segX - preceedingCharacterW + ((preceedingCharacterW - seg.width)/2)
                 end
 
                 if seg.newline then segX = 0 + (padding / 2) end
 
-                SurfaceSetFont(seg.font)
                 SurfaceSetTextColor(font_color)
                 SurfaceSetTextPos(segX, segY)
                 SurfaceDrawText(seg.text)
 
                 -- Strike-through line
                 if seg.strikethrough then
-                    DrawFormattingLine(seg, segX, font_color, 0.55)
+                    -- seg.width, _ = surface.GetTextSize(seg.text)
+                    DrawFormattingLine(seg, segX, segY, font_color, 0.55)
                 end
 
                 -- Underline
                 if seg.underline then
-                    DrawFormattingLine(seg, segX, font_color, 0.87)
+                    -- seg.width, _ = surface.GetTextSize(seg.text)
+                    DrawFormattingLine(seg, segX, segY, font_color, 0.87)
                 end
 
                 segX = segX + seg.width
+
+                lastChar = string.sub(seg.text, -1)
             end
         end
     else

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -70,6 +70,7 @@ local function ProcessFormattedSegments(messageSegments, big)
         local outline = seg.outline or false
         local newline = seg.newline or false
         local descend = seg.descend or false
+        local ascend = seg.ascend or false
         local vertical = (not seg.descend) and seg.vertical or false
 
         local fontName = BuildFormattedFont(bold, italic, underline, strikethrough, shadow, outline, big)
@@ -95,6 +96,28 @@ local function ProcessFormattedSegments(messageSegments, big)
                     outline = outline,
                     newline = newline,
                     descend = descend,
+                })
+            end
+        elseif ascend then
+
+            print("Exploding ascend")
+            exploded = string.Split(seg.text, "")
+
+            for i, splitString in ipairs(exploded) do
+                local segW, segH = SurfaceGetTextSize(splitString)
+
+                local ascend = i ~= 1
+
+                TableInsert(segments, {
+                    text = splitString,
+                    font = fontName,
+                    width = segW,
+                    height = segH,
+                    underline = underline,
+                    strikethrough = strikethrough,
+                    outline = outline,
+                    newline = newline,
+                    ascend = ascend,
                 })
             end
         elseif vertical then
@@ -141,20 +164,22 @@ local function MeasureSegments(segments)
     local baseW = 0
     local totalW = 0
     -- no need to measure maxH for segments as it's always the same
-    local totalH = 0
+    local totalDown = 0
+    local totalUp = 0
     local baseH = 0
 
     for _, seg in ipairs(segments) do
         if seg.width > baseW then baseW = seg.width end
         if not seg.newline then totalW = totalW + seg.width end
         if baseH == 0 then baseH = seg.height end
-        if seg.descend or seg.newline or seg.vertical then totalH = totalH + seg.height end
+        if seg.descend or seg.newline or seg.vertical then totalDown = totalDown + seg.height end
+        if seg.ascend then totalUp = totalUp + seg.height end
     end
 
     totalW = math.max(totalW, baseW)
-    totalH = totalH + baseH
+    local totalH = math.max(totalDown, totalUp) + baseH
 
-    return totalW, totalH
+    return totalW, totalDown, totalUp, baseH
 end
 
 local COLOR_DEFAULT = Color(255, 200, 0)
@@ -273,14 +298,21 @@ local function ShowMessage()
     local tag = net.ReadString()
     if tag == "" then tag = "default" end
 
+    local yOffset = nil
     local msgW, msgH
     local padding = big and 10 or 8
     local segments
 
     if formatted then
+        local totalDown
+        local totalUp
+        local baseH
+        
         createdFonts = {}
         segments = ProcessFormattedSegments(msg, big)
-        msgW, msgH = MeasureSegments(segments)
+        msgW, totalDown, totalUp, baseH = MeasureSegments(segments)
+        msgH = math.max(totalDown, totalUp) + baseH
+        yOffset = (totalUp - totalDown) > 0 and (totalUp - totalDown) or 0
     else
         SurfaceSetFont(big and "RandomatHeader" or "RandomatSmallMsg")
         msgW, msgH = SurfaceGetTextSize(msg)
@@ -330,7 +362,7 @@ local function ShowMessage()
 
         function content:Paint(w, h)
             local segX = 0 + (padding / 2)
-            local segY = 0
+            local segY = 0 + yOffset
             local preceedingCharacterW = 0
             local lastChar = ""
 
@@ -341,6 +373,10 @@ local function ShowMessage()
 
                 if seg.descend or seg.newline then
                     segY = segY + seg.height
+                end
+
+                if seg.ascend then
+                    segY = segY - seg.height
                 end
 
                 if seg.vertical then

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -222,8 +222,16 @@ local function RepositionStack()
     local testY = newest.baseY
     for i = count - 1, 1, -1 do
         local entry = message_stack[i]
+        local below = message_stack[i + 1]
         if not IsValid(entry.panel) then continue end
-        testY = testY - entry.panel:GetTall() - STACK_GAP
+        
+        -- If messages are in the same group, stick them together
+        local thisGap = STACK_GAP
+        if below and entry.group == below.group then
+            thisGap = 0
+        end
+
+        testY = testY - entry.panel:GetTall() - thisGap
         if testY < 0 then
             stacksFit = false
             break
@@ -235,9 +243,16 @@ local function RepositionStack()
         newest.panel:SetY(newest.baseY)
         for i = count - 1, 1, -1 do
             local entry = message_stack[i]
-            local below = message_stack[i + 1].panel
-            if not IsValid(entry.panel) or not IsValid(below) then continue end
-            entry.panel:SetY(MathMax(below:GetY() - entry.panel:GetTall() - STACK_GAP, 0))
+            local below = message_stack[i + 1]
+            if not IsValid(entry.panel) or not IsValid(below.panel) then continue end
+            
+            -- Again, if messages are in the same group, stick them together
+            local thisGap = STACK_GAP
+            if entry.group == below.group then
+                thisGap = 0
+            end
+
+            entry.panel:SetY(MathMax(below.panel:GetY() - entry.panel:GetTall() - thisGap, 0))
         end
 
     -- If we ARE going to overflow then start putting new messages under the older ones
@@ -245,9 +260,16 @@ local function RepositionStack()
         message_stack[1].panel:SetY(0)
         for i = 2, count do
             local entry = message_stack[i]
-            local above = message_stack[i - 1].panel
-            if not IsValid(entry.panel) or not IsValid(above) then continue end
-            entry.panel:SetY(above:GetY() + above:GetTall() + STACK_GAP)
+            local above = message_stack[i - 1]
+            if not IsValid(entry.panel) or not IsValid(above.panel) then continue end
+            
+            -- Yet again, if messages are in the same group, stick them together
+            local thisGap = STACK_GAP
+            if entry.group == above.group then
+                thisGap = 0
+            end
+
+            entry.panel:SetY(above.panel:GetY() + above.panel:GetTall() + thisGap)
         end
 
         -- Safety net so that if a new message would go off the BOTTOM of the screen, the whole stack moves upwards instead
@@ -318,6 +340,8 @@ local function ShowMessage()
 
     local tag = net.ReadString()
     if tag == "" then tag = "default" end
+
+    local group = net.ReadUInt(32)
 
     local yOffset = nil
     local msgW, msgH
@@ -442,9 +466,9 @@ local function ShowMessage()
 
     -- If this is a big message and the only message in the stack is small, put this in front of the small one so it shows on top
     if big and #message_stack == 1 and not message_stack[1].panel.big then
-        TableInsert(message_stack, 1, { panel = panel, baseY = baseY, tag = tag })
+        TableInsert(message_stack, 1, { panel = panel, baseY = baseY, tag = tag, group = group })
     else
-        TableInsert(message_stack, { panel = panel, baseY = baseY, tag = tag })
+        TableInsert(message_stack, { panel = panel, baseY = baseY, tag = tag, group = group })
     end
 
     -- Reposition all messages now that we've added a new one

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -84,9 +84,6 @@ local function ProcessFormattedSegments(messageSegments, big)
 
         local fontName = BuildFormattedFont(bold, italic, underline, strikethrough, shadow, outline, big)
         SurfaceSetFont(fontName)
-
-        local exploded = {}
-
         if layoutShape then
             local exploded = StringSplit(seg.text, "")
 
@@ -191,7 +188,7 @@ local function RepositionStack()
         local entry = message_stack[i]
         local below = message_stack[i + 1]
         if not IsValid(entry.panel) then continue end
-        
+
         -- If messages are in the same group, stick them together
         local thisGap = STACK_GAP
         if below and entry.group == below.group then
@@ -212,7 +209,7 @@ local function RepositionStack()
             local entry = message_stack[i]
             local below = message_stack[i + 1]
             if not IsValid(entry.panel) or not IsValid(below.panel) then continue end
-            
+
             -- Again, if messages are in the same group, stick them together
             local thisGap = STACK_GAP
             if entry.group == below.group then
@@ -229,7 +226,7 @@ local function RepositionStack()
             local entry = message_stack[i]
             local above = message_stack[i - 1]
             if not IsValid(entry.panel) or not IsValid(above.panel) then continue end
-            
+
             -- Yet again, if messages are in the same group, stick them together
             local thisGap = STACK_GAP
             if entry.group == above.group then
@@ -316,10 +313,6 @@ local function ShowMessage()
     local segments
 
     if formatted then
-        local totalDown
-        local totalUp
-        local baseH
-        
         createdFonts = {}
         segments = ProcessFormattedSegments(msg, big)
         msgW, msgH, yOffset = MeasureSegments(segments)
@@ -363,7 +356,6 @@ local function ShowMessage()
         parent:Remove()
     end
 
-
     if formatted then
         local content = VguiCreate("DPanel", bg)
         content:Dock(FILL)
@@ -371,9 +363,9 @@ local function ShowMessage()
         local paintSegments = segments
 
         function content:Paint(w, h)
-            local segX = 0 + (padding / 2)
-            local segY = 0 + yOffset
-            local preceedingCharacterW = 0
+            local segX = padding / 2
+            local segY = yOffset
+            local preceedingCharacterW
             local lastChar = ""
 
             for _, seg in ipairs(paintSegments) do
@@ -391,7 +383,7 @@ local function ShowMessage()
 
                 if seg.vertical then
                     segY = segY + seg.height
-                    segX = segX - preceedingCharacterW + ((preceedingCharacterW - seg.width)/2)
+                    segX = segX - preceedingCharacterW + ((preceedingCharacterW - seg.width) / 2)
                 end
 
                 if seg.newline then segX = 0 + (padding / 2) end
@@ -412,7 +404,7 @@ local function ShowMessage()
 
                 segX = segX + seg.width
 
-                lastChar = string.sub(seg.text, -1)
+                lastChar = StringSub(seg.text, -1)
             end
         end
     else

--- a/lua/randomat2/cl_message.lua
+++ b/lua/randomat2/cl_message.lua
@@ -58,7 +58,9 @@ local function ProcessFormattedSegments(messageSegments, big)
     local segments = {}
 
     for _, seg in ipairs(messageSegments) do
-        if not seg.text or seg.text == "" then continue end
+        if not seg.text then continue end
+        seg.text = string.Replace(seg.text, "\n", "")
+        if seg.text == "" then continue end
 
         local bold = seg.bold or false
         local italic = seg.italic or false
@@ -66,22 +68,22 @@ local function ProcessFormattedSegments(messageSegments, big)
         local strikethrough = seg.strikethrough or false
         local shadow = seg.shadow or false
         local outline = seg.outline or false
-        local linebreak = seg.linebreak or false
+        local newline = seg.newline or nil
+        local cascade = seg.cascade or nil
+        local vertical = (not cascade) and seg.vertical or nil
 
         local fontName = BuildFormattedFont(bold, italic, underline, strikethrough, shadow, outline, big)
         SurfaceSetFont(fontName)
 
-        local newLines = string.find(seg.text, "\n", 1)
         local exploded = {}
 
-        if newLines then
-            local startDrop = StartsWith(seg.text, "\n")
-            exploded = string.Split(seg.text, "\n")
+        if cascade then
+            exploded = string.Split(seg.text, "")
 
             for i, splitString in ipairs(exploded) do
                 local segW, segH = SurfaceGetTextSize(splitString)
 
-                local drop = Either(i == 1, startDrop, true)
+                local drop = i ~= 1
 
                 TableInsert(segments, {
                     text = splitString,
@@ -91,7 +93,7 @@ local function ProcessFormattedSegments(messageSegments, big)
                     underline = underline,
                     strikethrough = strikethrough,
                     outline = outline,
-                    linebreak = linebreak,
+                    newline = newline,
                     drop = drop,
                 })
             end
@@ -107,7 +109,7 @@ local function ProcessFormattedSegments(messageSegments, big)
                 underline = underline,
                 strikethrough = strikethrough,
                 outline = outline,
-                linebreak = linebreak,
+                newline = newline,
             })
         end
     end
@@ -125,9 +127,9 @@ local function MeasureSegments(segments)
 
     for _, seg in ipairs(segments) do
         if seg.width > baseW then baseW = seg.width end
-        if not seg.linebreak then totalW = totalW + seg.width end
+        if not seg.newline then totalW = totalW + seg.width end
         if baseH == 0 then baseH = seg.height end
-        if seg.drop or seg.linebreak then totalH = totalH + seg.height end
+        if seg.drop or seg.newline then totalH = totalH + seg.height end
     end
 
     totalW = math.max(totalW, baseW)
@@ -312,11 +314,11 @@ local function ShowMessage()
             local segY = 0
 
             for _, seg in ipairs(paintSegments) do
-                if seg.drop or seg.linebreak then
+                if seg.drop or seg.newline then
                     segY = segY + seg.height
                 end
 
-                if seg.linebreak then segX = 0 + (padding / 2) end
+                if seg.newline then segX = 0 + (padding / 2) end
 
                 SurfaceSetFont(seg.font)
                 SurfaceSetTextColor(font_color)

--- a/lua/randomat2/randomat_base.lua
+++ b/lua/randomat2/randomat_base.lua
@@ -19,6 +19,9 @@ local EntsFindByClass = ents.FindByClass
 local GetAllPlayers = player.GetAll
 local GetAllEnts = ents.GetAll
 local PlayerIterator = player.Iterator
+local TableInsert = table.insert
+local StringExplode = string.Explode
+local StringFind = string.find
 
 Randomat.ConVars = {
     "ttt_randomat_allow_client_list",
@@ -121,7 +124,7 @@ local function TruncateEventHistory(count)
         local extra = #Randomat.EventHistory - count
         local keep = {}
         for i = extra + 1, #Randomat.EventHistory, 1 do
-            table.insert(keep, Randomat.EventHistory[i])
+            TableInsert(keep, Randomat.EventHistory[i])
         end
         Randomat.EventHistory = keep
     end
@@ -171,7 +174,7 @@ local function LoadEventHistory()
     local history = string.Split(historyData, "\n")
     for _, h in ipairs(history) do
         if #h > 0 then
-            table.insert(Randomat.EventHistory, h)
+            TableInsert(Randomat.EventHistory, h)
         end
     end
 
@@ -200,7 +203,7 @@ function Randomat:AddEventToHistory(event)
     end
     if event == nil then return end
 
-    table.insert(Randomat.EventHistory, event.Id)
+    TableInsert(Randomat.EventHistory, event.Id)
     TruncateEventHistory(count)
     SaveEventHistory()
 end
@@ -286,7 +289,7 @@ local function TriggerEvent(event, ply, options, ...)
         Randomat:EventNotify(event.Title)
     end
 
-    table.insert(Randomat.ActiveEvents, event)
+    TableInsert(Randomat.ActiveEvents, event)
     event.owner = owner
     event.Owner = owner
     event.Silent = silent
@@ -333,7 +336,7 @@ local function TriggerEvent(event, ply, options, ...)
         if has_description then
             msg = msg .. " | " .. Randomat:GetEventDescription(event)
         end
-        table.insert(secret_event_chat_msgs, msg)
+        TableInsert(secret_event_chat_msgs, msg)
     end
 
     -- Let other addons know that an event was started
@@ -421,7 +424,7 @@ function Randomat:register(tbl)
         local lower_cats = {}
         for _, v in ipairs(tbl.Categories) do
             if v and #v > 0 then
-                table.insert(lower_cats, v:lower())
+                TableInsert(lower_cats, v:lower())
             end
         end
         tbl.Categories = lower_cats
@@ -431,9 +434,9 @@ function Randomat:register(tbl)
         tbl.ConVars = {}
     end
     -- And then save the default ones into it
-    table.insert(tbl.ConVars, "ttt_randomat_" .. id)
-    table.insert(tbl.ConVars, "ttt_randomat_" .. id .. "_min_players")
-    table.insert(tbl.ConVars, "ttt_randomat_" .. id .. "_weight")
+    TableInsert(tbl.ConVars, "ttt_randomat_" .. id)
+    TableInsert(tbl.ConVars, "ttt_randomat_" .. id .. "_min_players")
+    TableInsert(tbl.ConVars, "ttt_randomat_" .. id .. "_weight")
 
     setmetatable(tbl, randomat_meta)
 
@@ -554,7 +557,7 @@ local function GetRandomWeightedEvent(events, can_run)
             weight = default_weight
         end
         for _ = 1, weight do
-            table.insert(weighted_events, id)
+            TableInsert(weighted_events, id)
         end
     end
 
@@ -685,7 +688,7 @@ function Randomat:GetReadableCategory(category)
     elseif category == "modelchange" then
         return "Model Change"
     elseif string.StartsWith(category, "biased_") then
-        local parts = string.Explode("_", category)
+        local parts = StringExplode("_", category)
         for k, p in ipairs(parts) do
             parts[k] = Randomat:Capitalize(p)
         end
@@ -708,7 +711,7 @@ function Randomat:GetAllEventCategories(readable)
             end
             if table.HasValue(categories, cat) then continue end
 
-            table.insert(categories, cat)
+            TableInsert(categories, cat)
         end
     end
     return categories
@@ -725,7 +728,7 @@ function Randomat:GetEventCategories(event, readable)
     if readable then
         categories = {}
         for _, c in ipairs(event.Categories) do
-            table.insert(categories, Randomat:GetReadableCategory(c))
+            TableInsert(categories, Randomat:GetReadableCategory(c))
         end
     else
         categories = event.Categories
@@ -747,7 +750,7 @@ function Randomat:GetEventsByCategory(category, active)
     local lower_cat = category:lower()
     for _, e in pairs(tbl) do
         if type(e.Categories) == "table" and table.HasValue(e.Categories, lower_cat) then
-            table.insert(events, e)
+            TableInsert(events, e)
         end
     end
     return events
@@ -775,7 +778,7 @@ function Randomat:GetEventsByCategories(categories, active)
         end
 
         if has_all then
-            table.insert(events, e)
+            TableInsert(events, e)
         end
     end
     return events
@@ -801,7 +804,7 @@ function Randomat:GetEventsByType(etype)
     local events = {}
     for _, e in pairs(Randomat.Events) do
         if (e.Type == etype) or (type(e.Type) == "table" and table.HasValue(e.Type, etype)) then
-            table.insert(events, e)
+            TableInsert(events, e)
         end
     end
     return events
@@ -835,7 +838,7 @@ function Randomat:GetPlayers(shuffle, alive_only, dead_only, dead_includes_spec)
                 (alive_only and (ply:Alive() and not ply:IsSpec())) or
             -- Dead but not spec unless that's enabled
                 (dead_only and (not ply:Alive() or ply:IsSpec()) and (dead_includes_spec or ply:GetRole() ~= ROLE_NONE))) then
-                table.insert(plys, ply)
+                TableInsert(plys, ply)
             end
         end
     end
@@ -918,11 +921,11 @@ ParseNotifyLines = function(msg, big, length, targ, silent, allow_secret, font_c
 
         for _, seg in ipairs(msg) do
             if seg.newline and #currentLine > 0 then
-                table.insert(splitMessages, currentLine)
+                TableInsert(splitMessages, currentLine)
                 currentLine = {}
             end
 
-            local textChunks = string.Explode("\n", seg.text or "")
+            local textChunks = StringExplode("\n", seg.text or "")
 
             for i, chunk in ipairs(textChunks) do
                 if chunk ~= "" then
@@ -938,21 +941,21 @@ ParseNotifyLines = function(msg, big, length, targ, silent, allow_secret, font_c
                         ascend        = seg.ascend,
                         vertical      = seg.vertical,
                     }
-                    table.insert(currentLine, newSeg)
+                    TableInsert(currentLine, newSeg)
                 end
 
                 if i < #textChunks and #currentLine > 0 then
-                    table.insert(splitMessages, currentLine)
+                    TableInsert(splitMessages, currentLine)
                     currentLine = {}
                 end
             end
         end
 
         if #currentLine > 0 then
-            table.insert(splitMessages, currentLine)
+            TableInsert(splitMessages, currentLine)
         end
     else
-        splitMessages = string.Explode("\n", msg)
+        splitMessages = StringExplode("\n", msg)
     end
 
     if splitMessages then
@@ -972,12 +975,12 @@ SendNotify = function(msg, big, length, targ, silent, allow_secret, font_color, 
     local newlines
     if formatted then
         for _, seg in ipairs(msg) do
-            if string.find(seg.text, "\n") or seg.newline then
+            if StringFind(seg.text, "\n") or seg.newline then
                 newlines = true
             end
         end
     else
-        if string.find(msg, "\n") then
+        if StringFind(msg, "\n") then
             newlines = true
         end
     end
@@ -1321,7 +1324,7 @@ function randomat_meta:AddHook(hooktype, callbackfunc, suffix)
 
     self.Hooks = self.Hooks or {}
 
-    table.insert(self.Hooks, {hooktype, id})
+    TableInsert(self.Hooks, {hooktype, id})
 end
 
 function randomat_meta:RemoveHook(hooktype, suffix)
@@ -1481,7 +1484,7 @@ function randomat_meta:SwapWeapons(ply, weapon_list)
         new_cr = true
         for _, w in ipairs(ply:GetWeapons()) do
             if w.Category == WEAPON_CATEGORY_ROLE then
-                table.insert(role_weapons, w)
+                TableInsert(role_weapons, w)
             end
         end
     end
@@ -1551,7 +1554,7 @@ function randomat_meta:SetAllPlayerScales(scale)
     self:AddHook("TTTSpeedMultiplier", function(ply, mults)
         if not ply:Alive() or ply:IsSpec() then return end
         local speed_factor = math.Clamp(ply:GetStepSize() / 9, 0.25, 1)
-        table.insert(mults, speed_factor)
+        TableInsert(mults, speed_factor)
     end)
 end
 
@@ -1677,8 +1680,8 @@ local function ClearAutoComplete(cmd, args)
     local name = string.Trim(args):lower()
     local options = {}
     for _, v in pairs(Randomat.ActiveEvents) do
-        if string.find(v.Id:lower(), name) then
-            table.insert(options, cmd .. " " .. v.Id)
+        if StringFind(v.Id:lower(), name) then
+            TableInsert(options, cmd .. " " .. v.Id)
         end
     end
     return options
@@ -1703,8 +1706,8 @@ local function TriggerAutoComplete(cmd, args)
     local name = string.Trim(args):lower()
     local options = {}
     for _, v in pairs(Randomat.Events) do
-        if string.find(v.Id:lower(), name) then
-            table.insert(options, cmd .. " " .. v.Id)
+        if StringFind(v.Id:lower(), name) then
+            TableInsert(options, cmd .. " " .. v.Id)
         end
     end
     return options

--- a/lua/randomat2/randomat_base.lua
+++ b/lua/randomat2/randomat_base.lua
@@ -912,7 +912,7 @@ end
 
 local SendNotify, ParseNotifyLines
 
-ParseNotifyLines = function(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+ParseNotifyLines = function(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others, group)
     local formatted = type(msg) == "table"
     local splitMessages = {}
 
@@ -960,16 +960,23 @@ ParseNotifyLines = function(msg, big, length, targ, silent, allow_secret, font_c
 
     if splitMessages then
         for _, message in ipairs(splitMessages) do
-            SendNotify(message, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+            SendNotify(message, big, length, targ, silent, allow_secret, font_color, tag, clear_others, group)
         end
     end
 end
 
-SendNotify = function(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+local messageGroupCounter = 0
+
+SendNotify = function(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others, group)
     -- Don't broadcast anything when "Secret" is running unless we're told to bypass that
     if not allow_secret and Randomat:IsEventActive("secret") then return end
     if not msg or #msg == 0 then return end
     local formatted = type(msg) == "table"
+
+    if not group then
+        messageGroupCounter = messageGroupCounter + 1
+        group = messageGroupCounter
+    end
 
     -- Check for `\n` or `newline = true`
     local newlines
@@ -986,7 +993,7 @@ SendNotify = function(msg, big, length, targ, silent, allow_secret, font_color, 
     end
 
     if newlines then
-        ParseNotifyLines(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+        ParseNotifyLines(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others, group)
         return
     end
 
@@ -1007,6 +1014,7 @@ SendNotify = function(msg, big, length, targ, silent, allow_secret, font_color, 
     net.WriteUInt(length, 8)
     net.WriteColor(font_color or COLOR_BLANK)
     net.WriteString(tag or "")
+    net.WriteUInt(group, 32)
     if not targ then net.Broadcast() else net.Send(targ) end
 end
 

--- a/lua/randomat2/randomat_base.lua
+++ b/lua/randomat2/randomat_base.lua
@@ -907,17 +907,91 @@ function Randomat:ClearMessages(tag, targ)
     if not targ then net.Broadcast() else net.Send(targ) end
 end
 
-local function SendNotify(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+local SendNotify, ParseNotifyLines
+
+ParseNotifyLines = function(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+    local formatted = type(msg) == "table"
+    local splitMessages = {}
+
+    if formatted then
+        local currentLine = {}
+
+        for _, seg in ipairs(msg) do
+            if seg.newline and #currentLine > 0 then
+                table.insert(splitMessages, currentLine)
+                currentLine = {}
+            end
+
+            local textChunks = string.Explode("\n", seg.text or "")
+
+            for i, chunk in ipairs(textChunks) do
+                if chunk ~= "" then
+                    local newSeg = {
+                        text          = chunk,
+                        bold          = seg.bold,
+                        italic        = seg.italic,
+                        underline     = seg.underline,
+                        strikethrough = seg.strikethrough,
+                        shadow        = seg.shadow,
+                        outline       = seg.outline,
+                        descend       = seg.descend,
+                        ascend        = seg.ascend,
+                        vertical      = seg.vertical,
+                    }
+                    table.insert(currentLine, newSeg)
+                end
+
+                if i < #textChunks and #currentLine > 0 then
+                    table.insert(splitMessages, currentLine)
+                    currentLine = {}
+                end
+            end
+        end
+
+        if #currentLine > 0 then
+            table.insert(splitMessages, currentLine)
+        end
+    else
+        splitMessages = string.Explode("\n", msg)
+    end
+
+    if splitMessages then
+        for _, message in ipairs(splitMessages) do
+            SendNotify(message, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+        end
+    end
+end
+
+SendNotify = function(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
     -- Don't broadcast anything when "Secret" is running unless we're told to bypass that
     if not allow_secret and Randomat:IsEventActive("secret") then return end
     if not msg or #msg == 0 then return end
+    local formatted = type(msg) == "table"
+
+    -- Check for `\n` or `newline = true`
+    local newlines
+    if formatted then
+        for _, seg in ipairs(msg) do
+            if string.find(seg.text, "\n") or seg.newline then
+                newlines = true
+            end
+        end
+    else
+        if string.find(msg, "\n") then
+            newlines = true
+        end
+    end
+
+    if newlines then
+        ParseNotifyLines(msg, big, length, targ, silent, allow_secret, font_color, tag, clear_others)
+        return
+    end
 
     -- if clear_others then do that before sending new message
     if clear_others then
         Randomat:ClearMessages()
     end
 
-    local formatted = type(msg) == "table"
     if not isnumber(length) then length = 0 end
     net.Start(silent and "randomat_message_silent" or "randomat_message")
     net.WriteBool(big)


### PR DESCRIPTION
**Summary:**
- Formatted messages now include the flags `descend`, `ascend`, `vertical` and `newline`
- `newline` is treated as if the segment's string started with `"\n"`
- `\n` is treated the same for both formatted and unformatted messages: it splits all subsequent text onto a new line, centred on the x axis like a new message but without a gap in the background box

**Overview of implementation:**
randomat_base.lua:
- `SendNotify()` now assigns each received message a unique `group` identifier (if it doesn't already have one), then checks the received message for `newline = true` in formatted messages, and `\n` in formatted and unformatted messages
- If present, the message is then sent with the entire message data to `ParseNotifyLines()`, which splits the message up into separate messages delineated by the `\n`s and/or any `newline` segments
- `ParseNotifyLines()` then runs `SendNotify()` for each 'new' message in that group, which sends them to the client as before, other than also including the group identifiers

cl_message.lua:
- The client processes the messages as before, other than `RepositionStack()` now sets the gap between messages with the same group identifier to 0
- Work was also done fixing the positioning and background for formatted messages with `descend`, `ascend` and/or `vertical`: `MeasureSegments()` now tracks the minimum and maximum y positions of each segment and then uses that to calculate the total height of the message and any necessary y offset